### PR TITLE
Add AWS ECS cluster resource

### DIFF
--- a/terraform/backend/base/ecs.tf
+++ b/terraform/backend/base/ecs.tf
@@ -1,0 +1,9 @@
+resource "aws_ecs_cluster" "main" {
+  name = "magische-${var.environment}-${var.service}"
+
+  tags = {
+    Name    = "magische-${var.environment}-${var.service}-ecs-cluster"
+    Service = "${var.service}"
+    Env     = "${var.environment}"
+  }
+}

--- a/terraform/backend/base/variables.tf
+++ b/terraform/backend/base/variables.tf
@@ -1,0 +1,7 @@
+variable "environment" {
+  type = string
+}
+
+variable "service" {
+  type = string
+}

--- a/terraform/backend/dev/.terraform.lock.hcl
+++ b/terraform/backend/dev/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.38.0"
+  constraints = "~> 5.38.0"
+  hashes = [
+    "h1:axFddT4mkdtZREgkDXwXdzZGm1qxheF0fLN7S7bJJX4=",
+    "zh:0d58264440fd28b6729990b48d8fd61e732f5570689d17bbbc0c5f2324d3dd00",
+    "zh:175e24a3d399495fc91da359cc30a9fe06b7eeb98804816abcf1493859f6d28e",
+    "zh:244a1f56d6710cc1a643f602a185b46d3cd064f6df60330006f92ab32f3ff60c",
+    "zh:30dd99413867b1be808b656551a2f0452e4e37787f963780c51f1f85bf406441",
+    "zh:3629d4e212c8ffd8e74c4ab9e9d22ca7fff803052366d011c014591fa65beb48",
+    "zh:521badb184bbdde5dddb1228f7a241997db52ea51c9f8039ed5a626362952cf4",
+    "zh:5580a937e1f5fa59c16c4b9802079aa45a16c7c69e5b7d4e97aebf2c0fb4bd00",
+    "zh:87b801057d492ff0adc82ce6251871d87bdf5890749fe5753f447ec6fe4710ff",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c44e0c143f1d021440e9c448a9bc595f51a95e6cc382fcffe9db6d3b17f24c2",
+    "zh:b7e6b7b182932a3dbb6ca5f8ebb8d37befe1456f3dffaafb37cee07dc0473696",
+    "zh:d43fcf4f59cf79b1be3bec164d95fe9edc3fe39195a83226b911918a6538c8b3",
+    "zh:ec3e383ce1e414f0bd7d3fe73409ff7d2777a5da27248b70fd5df1df323d920b",
+    "zh:f729b443179bb115bbcbb0369fe46640de1c6dbd627b52694e9b3b8a41ec7881",
+    "zh:fd532b707746145d3c6d3507bca2b8d44cc618b3d5006db99426221b71db7da7",
+  ]
+}

--- a/terraform/backend/dev/backend.tf
+++ b/terraform/backend/dev/backend.tf
@@ -17,4 +17,5 @@ terraform {
 
 provider "aws" {
   region = "ap-northeast-1"
+  # profile = "magische"
 }

--- a/terraform/backend/dev/main.tf
+++ b/terraform/backend/dev/main.tf
@@ -1,0 +1,6 @@
+module "base" {
+  source = "../base"
+
+  environment = "dev"
+  service     = "backend"
+}


### PR DESCRIPTION
This pull request adds a new AWS ECS cluster resource to the Terraform configuration. The cluster is named "magische-{environment}-{service}-ecs-cluster" and has tags for the service and environment.