### PR TITLE
Add ACM certificates and load balancer resources

### DIFF
--- a/terraform/base/acm.tf
+++ b/terraform/base/acm.tf
@@ -1,0 +1,82 @@
+resource "aws_acm_certificate" "magische_net_tokyo" {
+  domain_name       = "magi-sche.net"
+  validation_method = "DNS"
+  subject_alternative_names = [
+    "*.magi-sche.net",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name = "magi-sche.net-certificate-tokyo"
+  }
+}
+
+resource "aws_acm_certificate" "magische_net_virginia" {
+  provider          = aws.virginia
+  domain_name       = "magi-sche.net"
+  validation_method = "DNS"
+  subject_alternative_names = [
+    "*.magi-sche.net",
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name = "magi-sche.net-certificate-virginia"
+  }
+}
+
+locals {
+  zone_id = aws_route53_zone.magische_net.zone_id
+}
+
+resource "aws_route53_record" "cert_validation_tokyo" {
+  for_each = {
+    for dvo in aws_acm_certificate.magische_net_tokyo.domain_validation_options : dvo.domain_name => {
+      name    = dvo.resource_record_name
+      type    = dvo.resource_record_type
+      zone_id = local.zone_id
+      record  = dvo.resource_record_value
+    }
+  }
+
+  zone_id = each.value.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 60
+}
+
+resource "aws_route53_record" "cert_validation_virginia" {
+  provider = aws.virginia
+  for_each = {
+    for dvo in aws_acm_certificate.magische_net_virginia.domain_validation_options : dvo.domain_name => {
+      name    = dvo.resource_record_name
+      type    = dvo.resource_record_type
+      zone_id = local.zone_id
+      record  = dvo.resource_record_value
+    }
+  }
+
+  zone_id = each.value.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  records = [each.value.record]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "magische_net_tokyo" {
+  certificate_arn         = aws_acm_certificate.magische_net_tokyo.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation_tokyo : record.fqdn]
+}
+
+resource "aws_acm_certificate_validation" "magische_net_virginia" {
+  provider                = aws.virginia
+  certificate_arn         = aws_acm_certificate.magische_net_virginia.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation_virginia : record.fqdn]
+}

--- a/terraform/base/backend.tf
+++ b/terraform/base/backend.tf
@@ -21,10 +21,10 @@ terraform {
 
 provider "aws" {
   region = "ap-northeast-1"
-  # profile = "magische"
 }
-# provider "aws" {
-#   alias   = "virginia"
-#   profile = "magische"
-#   region  = "us-east-1"
-# }
+provider "aws" {
+  alias  = "virginia"
+  region = "us-east-1"
+}
+
+data "aws_caller_identity" "current" {}

--- a/terraform/base/elb.tf
+++ b/terraform/base/elb.tf
@@ -1,0 +1,39 @@
+resource "aws_lb" "main" {
+  name               = "magische-base-lb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.lb.id]
+  subnets = [
+    aws_subnet.public_1a.id,
+    aws_subnet.public_1c.id,
+    aws_subnet.public_1d.id
+  ]
+  enable_waf_fail_open = true
+
+  access_logs {
+    bucket  = aws_s3_bucket.lb_logs.bucket
+    enabled = true
+  }
+
+  tags = {
+    Name = "magische-base-lb"
+  }
+}
+
+
+resource "aws_lb_listener" "main" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate.magische_net_tokyo.arn
+
+  default_action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      status_code  = "404"
+      message_body = "404 Not Found"
+    }
+  }
+}

--- a/terraform/base/output.tf
+++ b/terraform/base/output.tf
@@ -25,3 +25,19 @@ output "private_subnet_1c_id" {
 output "private_subnet_1d_id" {
   value = aws_subnet.private_1d.id
 }
+
+output "lb_arn" {
+  value = aws_lb.main.arn
+}
+output "lb_listener_arn" {
+  value = aws_lb_listener.main.arn
+}
+output "lb_security_group_id" {
+  value = aws_security_group.lb.id
+}
+output "acm_certificate_tokyo_arn" {
+  value = aws_acm_certificate.magische_net_tokyo.arn
+}
+output "acm_certificate_virginia_arn" {
+  value = aws_acm_certificate.magische_net_virginia.arn
+}

--- a/terraform/base/s3.tf
+++ b/terraform/base/s3.tf
@@ -1,0 +1,37 @@
+resource "aws_s3_bucket" "lb_logs" {
+  bucket = "magische-lb-logs-bucket"
+
+  tags = {
+    Name = "magische-lb-logs-bucket"
+  }
+}
+
+resource "aws_s3_bucket_policy" "lb_logs" {
+  bucket = aws_s3_bucket.lb_logs.bucket
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "delivery.logs.amazonaws.com"
+        },
+        Action   = "s3:PutObject",
+        Resource = "arn:aws:s3:::magische-lb-logs-bucket/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl" = "bucket-owner-full-control"
+          }
+        }
+      },
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "delivery.logs.amazonaws.com"
+        },
+        Action   = "s3:GetBucketAcl",
+        Resource = "arn:aws:s3:::magische-lb-logs-bucket"
+      },
+    ],
+  })
+}

--- a/terraform/base/security_group.tf
+++ b/terraform/base/security_group.tf
@@ -1,0 +1,8 @@
+resource "aws_security_group" "lb" {
+  name   = "magische-lb"
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "magische-lb"
+  }
+}


### PR DESCRIPTION
This pull request adds ACM certificates and load balancer resources to the Terraform configuration. The ACM certificates are created for the domain "magi-sche.net" in the Tokyo and Virginia regions. The load balancer resources include an application load balancer, a listener for HTTPS traffic on port 443, and a security group. Additionally, an S3 bucket is created for storing load balancer logs.